### PR TITLE
ignore logs from consumer thread and native logs

### DIFF
--- a/discord_lumberjack/handlers/discord_handler.py
+++ b/discord_lumberjack/handlers/discord_handler.py
@@ -110,9 +110,7 @@ class DiscordHandler(logging.Handler):
 		Raises:
 			Exception: If an exception was raised while sending a message, and `raise_exceptions` is True.
 		"""
-		logger.debug(
-			f"Flushing: Waiting for queue (size={self.__queue.qsize()}) to empty..."
-		)
+		logger.debug(f"Flushing: Waiting for queue to empty...")
 		self.__queue.join()
 		logger.debug("Flushing: Queue has been emptied.")
 		if self.__exception and raise_exceptions:
@@ -139,7 +137,6 @@ class DiscordHandler(logging.Handler):
 				self.__queue.task_done()
 				logger.debug(
 					f"Consumer: Finished processing message: {_record_str(record)}."
-					f" Queue size: {self.__queue.qsize()}"
 				)
 
 	def __send_message(self, message: Mapping[str, Any]) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest==6.2.5
+pytest-timeout==2.1.0
 python-dotenv==0.19.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pytest import fixture
-from typing import Callable
+from typing import Callable, Generator
 import os
 import logging
 from logging import FileHandler, LogRecord, Logger
@@ -110,3 +110,21 @@ def function_that_raises() -> Callable[[], None]:
 		raise ValueError("This is a test ValueError exception.")
 
 	return _function_that_raises
+
+
+@fixture
+def root_logger(handler: DiscordHandler) -> Generator[Logger, None, None]:
+	_root_logger = logging.getLogger()
+	_handlers = _root_logger.handlers
+	_filters = _root_logger.filters
+	_log_level = _root_logger.level
+
+	_root_logger.handlers = []
+	_root_logger.filters = []
+	_root_logger.addHandler(handler)
+	_root_logger.setLevel(logging.DEBUG)
+	yield _root_logger
+
+	_root_logger.handlers = _handlers
+	_root_logger.filters = _filters
+	_root_logger.level = _log_level

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -29,7 +29,7 @@ def test_log_speed(logger_with_all_handlers: Logger):
 	), f"Logging took too long. Limit is {limit} seconds. Took {diff} seconds."
 
 
-@pytest.mark.timeout(3)
+@pytest.mark.timeout(10)
 def test_recursion(root_logger: Logger):
 	"""Make sure there's no infinite recursion when a DiscordHandler is added to the root logger."""
 	root_logger.info(f"Pop goes the stack...")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,5 +1,5 @@
 import time
-from pytest import raises
+import pytest
 from logging import Logger
 from tests.utils import assert_messages_sent
 
@@ -12,7 +12,7 @@ def test_handler(logger: Logger):
 
 def test_untextable_user(logger_with_untextable_user: Logger):
 	"""Log a message with each handler."""
-	with raises(Exception):
+	with pytest.raises(Exception):
 		logger_with_untextable_user.info(f"test_untextable_user failed.")
 		assert_messages_sent(logger_with_untextable_user)
 
@@ -27,3 +27,10 @@ def test_log_speed(logger_with_all_handlers: Logger):
 	assert (
 		diff < limit
 	), f"Logging took too long. Limit is {limit} seconds. Took {diff} seconds."
+
+
+@pytest.mark.timeout(3)
+def test_recursion(root_logger: Logger):
+	"""Make sure there's no infinite recursion when a DiscordHandler is added to the root logger."""
+	root_logger.info(f"Pop goes the stack...")
+	assert_messages_sent(root_logger)


### PR DESCRIPTION
close #54 

DiscordHandler classes will not handle any logs from this module (i.e. logs sent to loggers with a name `discord_lumberjack.*`).
DiscordHandler classes also won't handle logs emitted from the consumer thread.
This avoids recursion